### PR TITLE
[FIX] jest setup 파일이 트랜스파일링 안되던 이슈 

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  setupFilesAfterEnv: ['<rootDir>/src/jest.setup.ts'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,0 @@
-require('@testing-library/jest-dom');

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## 개요
- https://github.com/pickly-team/pickly-frontend/pull/2/files#r1073434920 에서 
- jest.setup.js 가 파일이 트랜스파일링이 안돼서 import 구문이 안먹던 이슈 존재

## 원인
- tsconfig 설정에서 "include":["src"]로 되어있어 src폴더 외부에 있던 jest.setup.js 이 트랜스파일링이 안됐던것~!

## 해결 
- src 폴더 내부로 이동시켜줘서 해결!