### PR TITLE
[FEATURE] slide item common UI

### DIFF
--- a/src/common-ui/SlideItem.test.tsx
+++ b/src/common-ui/SlideItem.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@/test/utils';
+import SlideItem from '@/common-ui/SlideItem';
+import { screen } from '@testing-library/react';
+
+describe('SlideItem test', () => {
+  test('main 엘리먼트가 렌더링 된다.', () => {
+    //given
+    const MAIN = '슬라이드 아이템';
+
+    //when
+    render(<SlideItem main={<div>{MAIN}</div>} option={<></>} />);
+
+    //then
+    screen.getByText(MAIN);
+  });
+  test('option 엘리먼트가 렌더링 된다.', () => {
+    //given
+    const OPTION = '옵션';
+
+    //when
+    render(<SlideItem main={<></>} option={<div>{OPTION}</div>} />);
+
+    //then
+    screen.getByText(OPTION);
+  });
+  //TODO: cypress로 슬라이드 테스트 추가
+});

--- a/src/common-ui/SlideItem.test.tsx
+++ b/src/common-ui/SlideItem.test.tsx
@@ -18,7 +18,7 @@ describe('SlideItem test', () => {
     const OPTION = '옵션';
 
     //when
-    render(<SlideItem main={<></>} option={<div>{OPTION}</div>} />);
+    render(<SlideItem main={<div>Main</div>} option={<div>{OPTION}</div>} />);
 
     //then
     screen.getByText(OPTION);

--- a/src/common-ui/SlideItem.test.tsx
+++ b/src/common-ui/SlideItem.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@/test/utils';
 import SlideItem from '@/common-ui/SlideItem';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 
 describe('SlideItem test', () => {
   test('main 엘리먼트가 렌더링 된다.', () => {
@@ -24,4 +24,34 @@ describe('SlideItem test', () => {
     screen.getByText(OPTION);
   });
   //TODO: cypress로 슬라이드 테스트 추가
+  test('mouse event', () => {
+    //given
+    const MAIN = '슬라이드 아이템';
+    const OPTION = '옵션';
+
+    //when
+    render(<SlideItem main={<div>{MAIN}</div>} option={<div>{OPTION}</div>} />);
+    const element = screen.getByText(MAIN);
+    fireEvent.mouseDown(element);
+    fireEvent.mouseMove(element, { clientX: -100 });
+    fireEvent.mouseUp(element);
+
+    //then
+    screen.getByText(OPTION);
+  });
+  test('touch event', () => {
+    //given
+    const MAIN = '슬라이드 아이템';
+    const OPTION = '옵션';
+
+    //when
+    render(<SlideItem main={<div>{MAIN}</div>} option={<div>{OPTION}</div>} />);
+    const element = screen.getByText(MAIN);
+    fireEvent.touchStart(element);
+    fireEvent.touchMove(element, { clientX: -100 });
+    fireEvent.touchEnd(element);
+
+    //then
+    screen.getByText(OPTION);
+  });
 });

--- a/src/common-ui/SlideItem.test.tsx
+++ b/src/common-ui/SlideItem.test.tsx
@@ -47,8 +47,8 @@ describe('SlideItem test', () => {
     //when
     render(<SlideItem main={<div>{MAIN}</div>} option={<div>{OPTION}</div>} />);
     const element = screen.getByText(MAIN);
-    fireEvent.touchStart(element);
-    fireEvent.touchMove(element, { clientX: -100 });
+    fireEvent.touchStart(element, { touches: [{ clientX: 0 }] });
+    fireEvent.touchMove(element, { touches: [{ clientX: -100 }] });
     fireEvent.touchEnd(element);
 
     //then

--- a/src/common-ui/SlideItem.tsx
+++ b/src/common-ui/SlideItem.tsx
@@ -12,6 +12,7 @@ const SlideItem = ({ main, option, ...restProps }: SlideItemProps) => {
     useGetDivWrapperWidth();
   const innerWrapperRef = useRef<HTMLDivElement>(null);
   const mainRef = useRef<HTMLDivElement>(null);
+  const [isSlideEventStart, setIsSlideEventStart] = useState(false);
 
   // x 시작점
   const [startX, setStartX] = useState(0);
@@ -38,6 +39,7 @@ const SlideItem = ({ main, option, ...restProps }: SlideItemProps) => {
       const startX = currentTargetX - rect.left;
       setStartX(startX);
     }
+    setIsSlideEventStart(true);
   };
 
   const updateMovedPositionX = (currentTargetX: number) => {
@@ -45,6 +47,9 @@ const SlideItem = ({ main, option, ...restProps }: SlideItemProps) => {
     if (rect) {
       const moveX = currentTargetX - rect.left - startX;
       setMoveX(moveX);
+    }
+    if (isSlideEventStart && innerWrapperRef?.current) {
+      innerWrapperRef.current.style.left = `${moveX}px`;
     }
   };
 
@@ -55,6 +60,7 @@ const SlideItem = ({ main, option, ...restProps }: SlideItemProps) => {
       } else {
         innerWrapperRef.current.style.left = '0';
       }
+      setIsSlideEventStart(false);
     }
   };
 

--- a/src/common-ui/SlideItem.tsx
+++ b/src/common-ui/SlideItem.tsx
@@ -49,8 +49,18 @@ const SlideItem = ({ main, option, ...restProps }: SlideItemProps) => {
       const moveX = currentTargetX - rect.left - startX;
       setMoveX(moveX);
     }
-    if (isSlideEventStart && innerWrapperRef?.current) {
-      innerWrapperRef.current.style.left = `${moveX}px`;
+    if (isSlideEventStart && moveX < 0) {
+      handleSlideLeftEvent();
+    }
+  };
+
+  const handleSlideLeftEvent = () => {
+    const absoluteMoveX = Math.abs(moveX);
+    const adjustedMoveX =
+      absoluteMoveX > optionWrapperWidth ? optionWrapperWidth : absoluteMoveX;
+
+    if (innerWrapperRef?.current) {
+      innerWrapperRef.current.style.left = `-${adjustedMoveX}px`;
     }
   };
 

--- a/src/common-ui/SlideItem.tsx
+++ b/src/common-ui/SlideItem.tsx
@@ -1,5 +1,6 @@
 import { HTMLAttributes, ReactNode, useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
+import { theme } from '@/styles/theme';
 
 type SlideItemProps = {
   main: ReactNode;
@@ -175,5 +176,5 @@ const MainItemWrapper = styled.div`
 const OptionItemWrapper = styled.div`
   width: fit-content;
   height: 100%;
-  background-color: ${(p) => p.theme.colors.primary};
+  background-color: ${theme.colors.primary};
 `;

--- a/src/common-ui/SlideItem.tsx
+++ b/src/common-ui/SlideItem.tsx
@@ -21,6 +21,9 @@ const SlideItem = ({ main, option, ...restProps }: SlideItemProps) => {
   // 슬라이드 이벤트 시작했는지 표시
   const [isSlideEventStart, setIsSlideEventStart] = useState(false);
 
+  // 왼쪽으로 최대로 이동할 수 있는 거리
+  const maxLeftPositionX = optionWrapperWidth;
+
   useEffect(() => {
     initializeItemsStyle();
   }, [wrapperWidth]);
@@ -36,43 +39,55 @@ const SlideItem = ({ main, option, ...restProps }: SlideItemProps) => {
 
   const updateStartPositionX = (currentTargetX: number) => {
     const rect = wrapperRef.current?.getBoundingClientRect();
-    if (rect) {
-      const startX = currentTargetX - rect.left;
-      setStartX(startX);
+    if (!rect) {
+      return;
     }
+
+    const startX = currentTargetX - rect.left;
+
+    setStartX(startX);
     setIsSlideEventStart(true);
   };
 
   const updateMovedPositionX = (currentTargetX: number) => {
     const rect = wrapperRef.current?.getBoundingClientRect();
-    if (rect) {
-      const moveX = currentTargetX - rect.left - startX;
-      setMoveX(moveX);
+    if (!rect) {
+      return;
     }
-    if (isSlideEventStart && moveX < 0) {
-      handleSlideLeftEvent();
+    const moveX = currentTargetX - rect.left - startX;
+    setMoveX(moveX);
+
+    if (isSlideEventStart && isMoveToLeft(moveX)) {
+      handleLeftMovedPositionX();
     }
   };
 
-  const handleSlideLeftEvent = () => {
+  const handleLeftMovedPositionX = () => {
     const absoluteMoveX = Math.abs(moveX);
     const adjustedMoveX =
-      absoluteMoveX > optionWrapperWidth ? optionWrapperWidth : absoluteMoveX;
+      absoluteMoveX > maxLeftPositionX ? maxLeftPositionX : absoluteMoveX;
 
-    if (innerWrapperRef?.current) {
-      innerWrapperRef.current.style.left = `-${adjustedMoveX}px`;
-    }
+    changeSlideItemLeftPosition(`-${adjustedMoveX}`);
   };
 
   const moveToSlideDirection = () => {
-    if (innerWrapperRef?.current) {
-      if (moveX < 0) {
-        innerWrapperRef.current.style.left = `-${optionWrapperWidth}px`;
-      } else {
-        innerWrapperRef.current.style.left = '0';
-      }
-      setIsSlideEventStart(false);
+    if (isMoveToLeft(moveX)) {
+      changeSlideItemLeftPosition(`-${maxLeftPositionX}`);
+    } else {
+      changeSlideItemLeftPosition(0);
     }
+    setIsSlideEventStart(false);
+  };
+
+  const changeSlideItemLeftPosition = (leftMoveX: number | string) => {
+    if (!innerWrapperRef?.current) {
+      return;
+    }
+    innerWrapperRef.current.style.left = `${leftMoveX}px`;
+  };
+
+  const isMoveToLeft = (moveX: number) => {
+    return moveX < 0;
   };
 
   return (

--- a/src/common-ui/SlideItem.tsx
+++ b/src/common-ui/SlideItem.tsx
@@ -12,13 +12,14 @@ const SlideItem = ({ main, option, ...restProps }: SlideItemProps) => {
     useGetDivWrapperWidth();
   const innerWrapperRef = useRef<HTMLDivElement>(null);
   const mainRef = useRef<HTMLDivElement>(null);
-  const [isSlideEventStart, setIsSlideEventStart] = useState(false);
-
   // x 시작점
   const [startX, setStartX] = useState(0);
 
   // x 움직인 거리
   const [moveX, setMoveX] = useState(0);
+
+  // 슬라이드 이벤트 시작했는지 표시
+  const [isSlideEventStart, setIsSlideEventStart] = useState(false);
 
   useEffect(() => {
     initializeItemsStyle();

--- a/src/common-ui/SlideItem.tsx
+++ b/src/common-ui/SlideItem.tsx
@@ -120,9 +120,7 @@ const SlideItem = ({ main, option, ...restProps }: SlideItemProps) => {
     >
       <SlideInnerWrapper ref={innerWrapperRef}>
         <MainItemWrapper ref={mainRef}>{main}</MainItemWrapper>
-        {wrapperWidth && (
-          <OptionItemWrapper ref={optionWrapperRef}>{option}</OptionItemWrapper>
-        )}
+        <OptionItemWrapper ref={optionWrapperRef}>{option}</OptionItemWrapper>
       </SlideInnerWrapper>
     </SlideWrapper>
   );
@@ -132,7 +130,7 @@ export default SlideItem;
 
 const useGetDivWrapperWidth = () => {
   const ref = useRef<HTMLDivElement>(null);
-  const [width, setWidth] = useState(0);
+  const [width, setWidth] = useState(5000);
 
   useEffect(() => {
     function initializeData() {

--- a/src/common-ui/SlideItem.tsx
+++ b/src/common-ui/SlideItem.tsx
@@ -120,7 +120,9 @@ const SlideItem = ({ main, option, ...restProps }: SlideItemProps) => {
     >
       <SlideInnerWrapper ref={innerWrapperRef}>
         <MainItemWrapper ref={mainRef}>{main}</MainItemWrapper>
-        <OptionItemWrapper ref={optionWrapperRef}>{option}</OptionItemWrapper>
+        {wrapperWidth && (
+          <OptionItemWrapper ref={optionWrapperRef}>{option}</OptionItemWrapper>
+        )}
       </SlideInnerWrapper>
     </SlideWrapper>
   );

--- a/src/common-ui/SlideItem.tsx
+++ b/src/common-ui/SlideItem.tsx
@@ -4,7 +4,15 @@ import styled from '@emotion/styled';
 type SlideItemProps = {
   main: ReactNode;
   option: ReactNode;
-} & HTMLAttributes<HTMLDivElement>;
+} & Omit<
+  HTMLAttributes<HTMLDivElement>,
+  | 'onMouseMove'
+  | 'onMouseDown'
+  | 'onMouseUp'
+  | 'onTouchStart'
+  | 'onTouchMove'
+  | 'onTouchEnd'
+>;
 
 const SlideItem = ({ main, option, ...restProps }: SlideItemProps) => {
   const { ref: wrapperRef, width: wrapperWidth } = useGetDivWrapperWidth();

--- a/src/common-ui/SlideItem.tsx
+++ b/src/common-ui/SlideItem.tsx
@@ -105,13 +105,13 @@ const SlideItem = ({ main, option, ...restProps }: SlideItemProps) => {
         updateStartPositionX(event.clientX);
       }}
       onTouchStart={(event) => {
-        updateMovedPositionX(event.touches[0].clientX);
+        updateStartPositionX(event.touches[0].clientX);
       }}
       onMouseMove={(event) => {
         updateMovedPositionX(event.clientX);
       }}
       onTouchMove={(event) => {
-        updateStartPositionX(event.touches[0].clientX);
+        updateMovedPositionX(event.touches[0].clientX);
       }}
       onMouseUp={moveToSlideDirection}
       onTouchEnd={moveToSlideDirection}

--- a/src/common-ui/SlideItem.tsx
+++ b/src/common-ui/SlideItem.tsx
@@ -1,0 +1,139 @@
+import { HTMLAttributes, ReactNode, useEffect, useRef, useState } from 'react';
+import styled from '@emotion/styled';
+
+type SlideItemProps = {
+  main: ReactNode;
+  option: ReactNode;
+} & HTMLAttributes<HTMLDivElement>;
+
+const SlideItem = ({ main, option, ...restProps }: SlideItemProps) => {
+  const { ref: wrapperRef, width: wrapperWidth } = useGetDivWrapperWidth();
+  const { ref: optionWrapperRef, width: optionWrapperWidth } =
+    useGetDivWrapperWidth();
+  const innerWrapperRef = useRef<HTMLDivElement>(null);
+  const mainRef = useRef<HTMLDivElement>(null);
+
+  // x 시작점
+  const [startX, setStartX] = useState(0);
+
+  // x 움직인 거리
+  const [moveX, setMoveX] = useState(0);
+
+  useEffect(() => {
+    initializeItemsStyle();
+  }, [wrapperWidth]);
+
+  const initializeItemsStyle = () => {
+    if (mainRef?.current) {
+      mainRef.current.style.width = `${wrapperWidth}px`;
+    }
+    if (innerWrapperRef?.current) {
+      innerWrapperRef.current.style.left = '0';
+    }
+  };
+
+  const updateStartPositionX = (currentTargetX: number) => {
+    const rect = wrapperRef.current?.getBoundingClientRect();
+    if (rect) {
+      const startX = currentTargetX - rect.left;
+      setStartX(startX);
+    }
+  };
+
+  const updateMovedPositionX = (currentTargetX: number) => {
+    const rect = wrapperRef.current?.getBoundingClientRect();
+    if (rect) {
+      const moveX = currentTargetX - rect.left - startX;
+      setMoveX(moveX);
+    }
+  };
+
+  const moveToSlideDirection = () => {
+    if (innerWrapperRef?.current) {
+      if (moveX < 0) {
+        innerWrapperRef.current.style.left = `-${optionWrapperWidth}px`;
+      } else {
+        innerWrapperRef.current.style.left = '0';
+      }
+    }
+  };
+
+  return (
+    <SlideWrapper
+      ref={wrapperRef}
+      onMouseDown={(event) => {
+        updateStartPositionX(event.clientX);
+      }}
+      onTouchStart={(event) => {
+        updateMovedPositionX(event.touches[0].clientX);
+      }}
+      onMouseMove={(event) => {
+        updateMovedPositionX(event.clientX);
+      }}
+      onTouchMove={(event) => {
+        updateStartPositionX(event.touches[0].clientX);
+      }}
+      onMouseUp={moveToSlideDirection}
+      onTouchEnd={moveToSlideDirection}
+      {...restProps}
+    >
+      <SlideInnerWrapper ref={innerWrapperRef}>
+        <MainItemWrapper ref={mainRef}>{main}</MainItemWrapper>
+        <OptionItemWrapper ref={optionWrapperRef}>{option}</OptionItemWrapper>
+      </SlideInnerWrapper>
+    </SlideWrapper>
+  );
+};
+
+export default SlideItem;
+
+const useGetDivWrapperWidth = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    function initializeData() {
+      const width = ref?.current?.clientWidth;
+      if (width) {
+        setWidth(width);
+      }
+    }
+    window.addEventListener('resize', initializeData);
+    window.addEventListener('load', initializeData);
+
+    return () => {
+      window.removeEventListener('resize', initializeData);
+      window.removeEventListener('load', initializeData);
+    };
+  }, []);
+
+  return { ref, width };
+};
+
+const SlideWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  height: 80px;
+  overflow: hidden;
+  cursor: pointer;
+`;
+
+const SlideInnerWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: fit-content;
+  display: flex;
+  height: 100%;
+  transition: left 0.1s ease-in-out;
+`;
+
+const MainItemWrapper = styled.div`
+  height: 100%;
+`;
+
+const OptionItemWrapper = styled.div`
+  width: fit-content;
+  height: 100%;
+  background-color: ${(p) => p.theme.colors.primary};
+`;

--- a/src/components/Bear.tsx
+++ b/src/components/Bear.tsx
@@ -1,4 +1,5 @@
 import useBearStore from '@/store/bears';
+import SlideItem from '@/common-ui/SlideItem';
 
 const Bear = () => {
   const bears = useBearStore((state) => state.bears);
@@ -9,6 +10,10 @@ const Bear = () => {
       <div>bears: {bears}</div>
       <button onClick={increase}>증가</button>
       <button onClick={decrease}>감소</button>
+      <SlideItem
+        main={<div>hi</div>}
+        option={<div style={{ width: '200px' }}>option</div>}
+      />
     </>
   );
 };

--- a/src/components/Bear.tsx
+++ b/src/components/Bear.tsx
@@ -1,5 +1,4 @@
 import useBearStore from '@/store/bears';
-import SlideItem from '@/common-ui/SlideItem';
 
 const Bear = () => {
   const bears = useBearStore((state) => state.bears);
@@ -10,10 +9,6 @@ const Bear = () => {
       <div>bears: {bears}</div>
       <button onClick={increase}>증가</button>
       <button onClick={decrease}>감소</button>
-      <SlideItem
-        main={<div>hi</div>}
-        option={<div style={{ width: '200px' }}>option</div>}
-      />
     </>
   );
 };


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #11 
- SlideItem 컴포넌트 개발

<br>

## 🔨 작업 사항 (필수)

- SlideItem 컴포넌트 개발
  - 슬라이드 이벤트에 따른 로직 개발 ( 왼쪽 방향 : 옵션 엘리먼트 노출 / 오른쪽 방향 : 메인 엘리먼트 노출)
  - 렌더링 테스트 코드 추가
- 슬라이드 로직 
  1) **마우스 누르는 이벤트 시작시** (mousedown /  touchstart) :
      - `startX` 에 첫번째 클릭 x pos 값 저장 
  2) **마우스 이동시** (mosemove / touchmove) :
      - `moveX` 에 움직인 거리 저장 
  3) **마우스 누르는 이벤트 종료시** (mouseup / touchend) : 
      - 2)에서 계산된 이동거리의 +/-을 기준으로  
      - `왼쪽`으로 이동(-): `옵션 엘리먼트` 노출
      - `오른쪽`으로 이동(+): `메인 엘리먼트` 노출 

<br>

## ⚡️ 관심 리뷰 (선택)
- 내부 로직이 복잡해서 가독성 위주로 리뷰 받고싶습니다.
- react testing library 에서 overflow hidden에 따른 엘리먼트 노출 여부를 감지하지 못하고, mouse event 테스트하는것이 너무 불편해서 우선 해당 부분 테스트코드는 작성하지 않았습니다.
- 추후 cypress 붙이면 테스트코드 붙일수도?

<br>


<video src="https://user-images.githubusercontent.com/51521314/221393100-456c268a-8f45-4b7b-b273-8449aea329ba.mov">

   
