### PR TITLE
[FIX] Checkbox 테스트 깨지는 것 수정

### DIFF
--- a/src/common-ui/CheckBox.test.tsx
+++ b/src/common-ui/CheckBox.test.tsx
@@ -13,7 +13,7 @@ describe('Checkbox test', () => {
         Check
       </CheckBox>,
     );
-    const checkbox = screen.getByLabelText('Check');
+    const checkbox = screen.getByLabelText(/Check/);
     await userEvent.click(checkbox);
 
     //then
@@ -29,7 +29,7 @@ describe('Checkbox test', () => {
         Check
       </CheckBox>,
     );
-    const checkbox = screen.getByLabelText('Check');
+    const checkbox = screen.getByLabelText(/Check/);
     await userEvent.click(checkbox);
 
     //then
@@ -46,7 +46,7 @@ describe('Checkbox test', () => {
           Check
         </CheckBox>,
       );
-      const checkbox = screen.getByLabelText('Check');
+      const checkbox = screen.getByLabelText(/Check/);
       await userEvent.click(checkbox);
 
       //then


### PR DESCRIPTION
## 📌 개요 
- checkbox 테스트 깨지는 것 수정

<br>

## 🔨 작업 사항
- Icon 컴포넌트 내부에 <title>name</title> 이 추가되면서 labeltext 가 icon name 도 포함 된 문자열로 잡혀서 발행하는 문제였습니당
- 문자열 일치가 아닌 문자열 포함 정규식 (/Checkbox/)로 수정해서 해결했습니다.
