### PR TITLE
fix: array params 형식에 대해 qs 라이브러리를 이용한 방식으로 변경

### DIFF
--- a/src/bookmarks/api/bookmark.ts
+++ b/src/bookmarks/api/bookmark.ts
@@ -1,7 +1,7 @@
 import useToast from '@/common-ui/Toast/hooks/useToast';
 import client from '@/common/service/client';
 import { navigatePath } from '@/constants/navigatePath';
-
+import qs from 'qs';
 import {
   useInfiniteQuery,
   useMutation,
@@ -124,15 +124,8 @@ const DELETEBookMark = {
       params: {
         bookmarkId: params.bookmarkIds,
       },
-      paramsSerializer: {
-        encode: (params) => {
-          return Object.keys(params)
-            .map((key) =>
-              params[key].map((v: string) => `${key}=${v}`).join('&'),
-            )
-            .join('&');
-        },
-      },
+      paramsSerializer: (params) =>
+        qs.stringify(params, { arrayFormat: 'repeat' }),
     });
     return data;
   },

--- a/src/category/api/delete.ts
+++ b/src/category/api/delete.ts
@@ -2,7 +2,7 @@ import client from '@/common/service/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { GET_CATEGORY_LIST } from './category';
 import { GET_BOOKMARK_CATEGORY_LIST } from '@/bookmarks/api/bookmark';
-
+import qs from 'qs';
 interface DeleteCategoryRequest {
   memberId: number;
   categoryId: string[];
@@ -14,15 +14,8 @@ const DeleteCategory = {
       params: {
         categoryId: params.categoryId,
       },
-      paramsSerializer: {
-        encode: (params) => {
-          return Object.keys(params)
-            .map((key) =>
-              params[key].map((v: string) => `${key}=${v}`).join('&'),
-            )
-            .join('&');
-        },
-      },
+      paramsSerializer: (params) =>
+        qs.stringify(params, { arrayFormat: 'repeat' }),
     });
     return data;
   },


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #107
- PR의 메인 내용

1. array query param 형식의 api 수정

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] qs 라이브러리를 이용한 방식으로 변경

```ts
qs.stringify(params, { arrayFormat: 'repeat' })
```

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
