### PR TITLE
feat: 알림 페이지 API 연동

### DIFF
--- a/src/notification/ui/Notifications.tsx
+++ b/src/notification/ui/Notifications.tsx
@@ -1,20 +1,52 @@
 import NotificationSlideItem from '@/notification/ui/skeleton/NotificationSlideItem';
-import { useGetNotifications } from '@/notification/api/notification';
+import {
+  useDELETENotificationQuery,
+  useGETNotificationListQuery,
+  usePATCHNotificationReadQuery,
+} from '@/notification/api/notification';
+import useAuthStore from '@/store/auth';
 
 const Notifications = () => {
-  const { data } = useGetNotifications();
+  // FIRST RENDER
+  const { memberId } = useAuthStore();
+  const { data: notificationList } = useGETNotificationListQuery({ memberId });
+
+  // USER INTERACTION
+  // 1. 알림 읽음 처리
+  const { mutate: updateReadNotification } = usePATCHNotificationReadQuery({
+    memberId,
+  });
+  const onClickReadNotification = (
+    notificationId: number,
+    isChecked: boolean,
+  ) => {
+    !isChecked && updateReadNotification({ notificationId });
+  };
+
+  // 2. 알림 삭제
+  const { mutate: deleteNotification } = useDELETENotificationQuery({
+    memberId,
+  });
+  const onClickDeleteNotification = (notificationId: number) => {
+    deleteNotification({ notificationId });
+  };
 
   return (
     <>
-      {data?.map((notification) => (
+      {notificationList?.map((notification) => (
         <NotificationSlideItem
           key={notification.id}
           bookMarkInfo={{
-            id: notification.id,
-            title: notification.title,
+            id: String(notification.bookmarkId),
+            content: notification.content,
           }}
           createdAt={notification.createdAt}
-          isRead={notification.isRead}
+          isRead={notification.isChecked}
+          title={notification.title}
+          toggleReadNotification={() =>
+            onClickReadNotification(notification.id, notification.isChecked)
+          }
+          deleteNotification={() => onClickDeleteNotification(notification.id)}
         />
       ))}
     </>

--- a/src/notification/ui/skeleton/NotificationSlideItem.tsx
+++ b/src/notification/ui/skeleton/NotificationSlideItem.tsx
@@ -4,10 +4,10 @@ import getRem from '@/utils/getRem';
 import { theme } from '@/styles/theme';
 import Text from '@/common-ui/Text';
 import Icon from '@/common-ui/assets/Icon';
-import formatDateByStartAndEnd from '@/utils/date/formatDateByStartAndEnd';
 import { Link } from 'react-router-dom';
 import { navigatePath } from '@/constants/navigatePath';
 import getRandomElementFromArray from '@/utils/getRandomElementFromArray';
+import { timeStampToDate } from '@/utils/date/timeConverter';
 
 const NOTIFICATION_TITLES = [
   '읽지 않은 북마크가 있어요!',
@@ -19,34 +19,43 @@ const NOTIFICATION_TITLES = [
 interface NotificationSlideItemProps {
   bookMarkInfo: {
     id: string;
-    title: string;
+    content: string;
   };
-  createdAt: string;
+  createdAt: number;
   isRead: boolean;
+  title: string;
+  toggleReadNotification: () => void;
+  deleteNotification: () => void;
 }
 const NotificationSlideItem = ({
   bookMarkInfo,
   createdAt,
   isRead,
+  title = getRandomElementFromArray(NOTIFICATION_TITLES),
+  toggleReadNotification,
+  deleteNotification,
 }: NotificationSlideItemProps) => {
-  const { id, title } = bookMarkInfo;
+  const { id, content } = bookMarkInfo;
 
   const showEllipse = !isRead;
 
   return (
     <SlideItem
       main={
-        <NotificationInfoWrapper isRead={isRead}>
+        <NotificationInfoWrapper
+          isRead={isRead}
+          onClick={toggleReadNotification}
+        >
           <Text.Span fontSize={getRem(16)} weight={'bold'}>
-            {getRandomElementFromArray(NOTIFICATION_TITLES)}
+            {title}
           </Text.Span>
           <NotificationContentWrapper>
             <TitleAndCreatedAtLink
               to={`${navigatePath.BOOKMARK_DETAIL.replace(':id', id)}`}
             >
-              <TitleText fontSize={getRem(12)}>{title}</TitleText>
+              <TitleText fontSize={getRem(12)}>{content}</TitleText>
               <CreatedAtText fontSize={getRem(8)}>
-                {getFormattedCreatedAtByToday(createdAt)}
+                {timeStampToDate(createdAt)}
               </CreatedAtText>
             </TitleAndCreatedAtLink>
             <EllipseWrapper>
@@ -56,7 +65,7 @@ const NotificationSlideItem = ({
         </NotificationInfoWrapper>
       }
       option={
-        <DeleteWrapper>
+        <DeleteWrapper onClick={deleteNotification}>
           <DeleteIconAndTextWrapper>
             <Icon name={'trash'} size={'s'} />
             <Text.Span>삭제</Text.Span>
@@ -68,12 +77,6 @@ const NotificationSlideItem = ({
 };
 
 export default NotificationSlideItem;
-
-const getFormattedCreatedAtByToday = (createdAt: string) => {
-  const createdAtDate = new Date(createdAt);
-  const todayDate = new Date();
-  return formatDateByStartAndEnd(createdAtDate, todayDate);
-};
 
 const NotificationInfoWrapper = styled.div<{ isRead: boolean }>`
   height: ${getRem(80)};


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #119
- PR의 메인 내용

1. 알림 리스트 불러오기 API 
2. 알림 읽음 상태 토글 API
3. 알림 삭제 API 

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] 알림 리스트 불러오기 API 연동
- [x] 알림 읽음 상태 토글 API 연동
- [x] 알림 삭제 API 연동
- [x] 알림 삭제 후 알림 삭제 토스트 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 현재 백엔드 API에서 알림을 읽음 상태가 반영되지 않음 -> 추후 수정 필요
