### PR TITLE
fix: 임시로 사용되던 id 실제 memberId로 변경

### DIFF
--- a/src/bookmarks/service/hooks/add/useCategoryList.tsx
+++ b/src/bookmarks/service/hooks/add/useCategoryList.tsx
@@ -7,7 +7,6 @@ import useAuthStore from '@/store/auth';
 import { useQueryClient } from '@tanstack/react-query';
 
 const useCategoryList = () => {
-  // TODO : 추후 FIREBASE AUTH 연동 후 USER_ID 변경
   const { memberId } = useAuthStore();
   // SERVER
   const { data: categoryList } = useGETCategoryListQuery({

--- a/src/bookmarks/ui/Like/BookmarkLikeList.tsx
+++ b/src/bookmarks/ui/Like/BookmarkLikeList.tsx
@@ -5,22 +5,23 @@ import {
 import useBottomIntersection from '@/common/service/hooks/useBottomIntersection';
 import BookmarkLikeItem from './BookmarkLikeItem';
 import SkeletonBookmarkLikeList from './SkeletonBookmarkLikeList';
+import useAuthStore from '@/store/auth';
 
 const BookmarkLikeList = () => {
-  const USER_ID = 1;
+  const { memberId } = useAuthStore();
   const {
     data: bookmarkList,
     fetchNextPage,
     isFetchingNextPage,
   } = useGETLikeBookmarkListQuery({
-    memberId: USER_ID,
+    memberId,
     pageRequest: {
       cursorId: null,
       pageSize: 15,
     },
   });
 
-  const { mutate } = usePUTLikeBookmarkMutation({ memberId: USER_ID });
+  const { mutate } = usePUTLikeBookmarkMutation({ memberId });
 
   const onClickLike = (bookmarkId: number) => {
     mutate(bookmarkId);

--- a/src/category/ui/CategoryList.tsx
+++ b/src/category/ui/CategoryList.tsx
@@ -17,6 +17,7 @@ import useBottomIntersection from '@/common/service/hooks/useBottomIntersection'
 import SkeletonCategoryList from './SkeletonCategoryList';
 import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 import BlankItem from '@/common-ui/BlankItem';
+import useAuthStore from '@/store/auth';
 
 interface CategoryListProps {
   mode: Mode;
@@ -41,13 +42,13 @@ const CategoryList = ({
   setDeleteCategoryList,
 }: CategoryListProps) => {
   const navigate = useNavigate();
-  const USER_ID = 1;
+  const { memberId } = useAuthStore();
   const {
     data: categoryList,
     fetchNextPage,
     isFetchingNextPage,
   } = useGETCategoryListQuery({
-    memberId: USER_ID,
+    memberId,
     pageRequest: {
       pageSize: 15,
     },
@@ -87,7 +88,7 @@ const CategoryList = ({
       else setDeleteCategoryList([...deleteCategoryList, categoryId]);
 
       queryClient.setQueryData<InfiniteCategory>(
-        GET_CATEGORY_LIST(USER_ID),
+        GET_CATEGORY_LIST(memberId),
         (prev) => {
           if (!prev) return undefined;
           return {

--- a/src/common-ui/BottomNavigation.tsx
+++ b/src/common-ui/BottomNavigation.tsx
@@ -15,6 +15,7 @@ import { useEffect } from 'react';
 import { usePOSTBookmarkMutation } from '@/bookmarks/api/bookmark';
 import checkValidateURL from '@/utils/checkValidateURL';
 import ToastList from './Toast/ToastList';
+import useAuthStore from '@/store/auth';
 
 // TODO : 네비게이터에 대한 path를 재정의 필요
 
@@ -85,7 +86,7 @@ const BottomNavigation = () => {
     }
   }, []);
 
-  const MEMBER_ID = 1; // TODO : 로그인 기능 구현 후 수정 필요
+  const { memberId } = useAuthStore();
   const { mutate: postBookmark } = usePOSTBookmarkMutation({
     resetAll: {
       resetAllInputs,
@@ -95,7 +96,7 @@ const BottomNavigation = () => {
       },
       resetVisibility: () => onClickPublishScoped('SCOPE_PUBLIC'),
     },
-    memberId: MEMBER_ID,
+    memberId,
     categoryId: Number(selectedCategoryId),
   });
 
@@ -105,7 +106,7 @@ const BottomNavigation = () => {
       title,
       categoryId: Number(selectedCategoryId),
       visibility: selectedPublishScoped,
-      memberId: MEMBER_ID,
+      memberId,
     });
     close();
   };

--- a/src/pages/CategoryListPage.tsx
+++ b/src/pages/CategoryListPage.tsx
@@ -7,23 +7,23 @@ import SkeletonCategoryList from '@/category/ui/SkeletonCategoryList';
 import useBottomSheet from '@/common-ui/BottomSheet/hooks/useBottomSheet';
 import Header from '@/common-ui/Header/Header';
 import BSConfirmation from '@/common/ui/BSConfirmation';
+import useAuthStore from '@/store/auth';
 import { Suspense, useState } from 'react';
 
 const CategoryListPage = () => {
-  // TODO : 로그인 유저 ID 연동
-  const USER_ID = 1;
+  const { memberId } = useAuthStore();
   const [mode, setMode] = useState<Mode>('NORMAL');
 
   const { close, isOpen, open } = useBottomSheet();
 
   const [deleteCategoryList, setDeleteCategoryList] = useState<string[]>([]);
   const { mutateAsync: mutateDeleteCategory } = useDeleteCategoryMutation({
-    memberId: USER_ID,
+    memberId,
   });
   const onClickDelete = async () => {
     await mutateDeleteCategory({
       categoryId: deleteCategoryList,
-      memberId: USER_ID,
+      memberId,
     });
     setMode('NORMAL');
     close();
@@ -33,7 +33,7 @@ const CategoryListPage = () => {
   );
 
   const { mutateAsync: mutatePatchOrder } = usePATCHCategoryOrderMutation({
-    memberId: USER_ID,
+    memberId,
   });
   const onClickSaveOrder = async () => {
     const orderData = clientCategoryList.map((category, index) => ({

--- a/src/pages/CategoryManagePage.tsx
+++ b/src/pages/CategoryManagePage.tsx
@@ -15,6 +15,7 @@ import { usePOSTCategoryMutation } from '@/category/api/add';
 import { useGETCategoryAPI } from '@/category/api/category';
 import { useEffect } from 'react';
 import { usePUTCategoryMutation } from '@/category/api/edit';
+import useAuthStore from '@/store/auth';
 
 interface CategoryManagePageProps {
   mode: 'ADD' | 'EDIT';
@@ -22,7 +23,7 @@ interface CategoryManagePageProps {
 
 const CategoryManagePage = ({ mode }: CategoryManagePageProps) => {
   // TODO : 인증 로직 추가
-  const USER_ID = 1;
+  const { memberId } = useAuthStore();
   const router = useNavigate();
   const location = useLocation();
   const fromPath = location.state?.fromPath ?? '/';
@@ -38,7 +39,7 @@ const CategoryManagePage = ({ mode }: CategoryManagePageProps) => {
 
   const { data: categoryData } = useGETCategoryAPI({
     categoryId: categoryId ?? '',
-    memberId: USER_ID,
+    memberId,
     mode,
   });
   useEffect(() => {
@@ -65,17 +66,17 @@ const CategoryManagePage = ({ mode }: CategoryManagePageProps) => {
 
   // 2. 저장 버튼 > 저장
   const { mutate: postCategory } = usePOSTCategoryMutation({
-    memberId: USER_ID,
+    memberId,
   });
   const { mutate: putCategory } = usePUTCategoryMutation({
-    memberId: USER_ID,
+    memberId,
     categoryId: categoryId ?? '',
   });
   const onClickSave = () => {
     if (mode === 'EDIT') {
       putCategory({
         categoryId: categoryId ?? '',
-        memberId: USER_ID,
+        memberId,
         postData: {
           name: categoryName,
           emoji,
@@ -85,7 +86,7 @@ const CategoryManagePage = ({ mode }: CategoryManagePageProps) => {
     }
     if (mode === 'ADD') {
       postCategory({
-        memberId: USER_ID,
+        memberId,
         postData: categoryList.map((category) => ({
           emoji: category.emoji,
           name: category.name,

--- a/src/pages/CommentPage.tsx
+++ b/src/pages/CommentPage.tsx
@@ -3,11 +3,12 @@ import styled from '@emotion/styled';
 import CommentItem from '@/comment/ui/comment-list/CommentItem';
 import getRem from '@/utils/getRem';
 import { useGETCommentListQuery } from '@/comment/api/Comment';
+import useAuthStore from '@/store/auth';
 
 const CommentPage = () => {
-  const USER_ID = 1;
+  const { memberId } = useAuthStore();
   const { data: commentList } = useGETCommentListQuery({
-    userId: USER_ID,
+    userId: memberId,
   });
 
   return (


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #133
- PR의 메인 내용

1. 임시 사용 id 실제 memberId로 교체

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] 실제로 사용하는 memberId로 교체 - from `authStore`

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
