### PR TITLE
fix: 댓글 사용자 다르게 나오던 오류 수정

### DIFF
--- a/src/comment/ui/bookmark/CommentList.tsx
+++ b/src/comment/ui/bookmark/CommentList.tsx
@@ -42,7 +42,7 @@ const CommentList = () => {
         <CommentItem
           key={comment.id}
           content={comment.content}
-          isWriter={comment.member === userInfo.nickname}
+          isWriter={comment.isOwnerComment}
           nickname={comment.member}
           updatedAt={timeStampToDate(comment.createdTimestamp)}
           onClickEdit={() =>


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #151
- PR의 메인 내용

1. 댓글 사용자가 다르게 나오던 오류 수정

<br>

## 🔨 작업 사항 (필수)

- [x] `isOwnerComment`를 이용하여 자신의 게시물 판단 하도록 수정



<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
