### PR TITLE
fix: 친구 페이지 > 팔로잉 리스트의 유저 이모지가 제대로 출력되지 않던 오류 수정

### DIFF
--- a/src/friend/ui/friend/FriendFollowingItem.tsx
+++ b/src/friend/ui/friend/FriendFollowingItem.tsx
@@ -1,4 +1,3 @@
-import decodeEmojiBase64 from '@/utils/decodeEmojiBase64';
 import UnFollowButton from '@/friend/ui/buttons/UnFollowButton';
 import FriendItemLayout from '@/friend/ui/friend/layout/FriendItemLayout';
 import FollowButton from '@/friend/ui/buttons/FollowButton';
@@ -20,7 +19,7 @@ const FriendFollowingItem = ({
   return (
     <FriendItemLayout
       name={name}
-      emoji={profileEmoji && decodeEmojiBase64(profileEmoji)}
+      emoji={profileEmoji && profileEmoji}
       id={id}
       button={
         isFollowing ? (


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #153
- PR의 메인 내용

1. 친구 페이지 > 팔로잉 리스트의 유저 이모지가 제대로 출력되지 않던 오류 수정

<br>

## 🔨 작업 사항 (필수)

- [x] 이모지 decode 하는 로직 삭제

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
