### PR TITLE
fix: 북마크 게시물 관련 댓글로 불러와지도록 수정 및 댓글이 없는 경우 UI 추가

### DIFF
--- a/src/bookmarks/api/bookmark.ts
+++ b/src/bookmarks/api/bookmark.ts
@@ -436,32 +436,31 @@ export interface BookmarkCommentItem {
 }
 
 interface GETBookmarkCommentRequest {
-  memberId: number;
+  bookmarkId: string;
   token?: string;
 }
 
 const getBookmarkCommentListAPI = async ({
-  memberId,
+  bookmarkId,
   token,
 }: GETBookmarkCommentRequest) => {
   const { data } = await client<BookmarkCommentItem[]>({
     method: 'get',
-    url: `/members/${memberId}/comments`,
-    params: { memberId },
+    url: `/bookmarks/${bookmarkId}/comments`,
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
   return data;
 };
 
 export interface GetAPIRequest {
-  memberId: number;
+  bookmarkId: string;
   token?: string;
   setCommentCount?: (count: number) => void;
 }
 
 export const GET_BOOKMARK_COMMENT = (params: GetAPIRequest) => [
   'GET_BOOKMARK_COMMENT',
-  params.memberId,
+  params.bookmarkId,
 ];
 
 export const useGETBookmarkCommentListQuery = (params: GetAPIRequest) => {

--- a/src/comment/api/Comment.ts
+++ b/src/comment/api/Comment.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import client from '@/common/service/client';
 import { navigatePath } from '../../constants/navigatePath';
 import { GET_BOOKMARK_COMMENT } from '@/bookmarks/api/bookmark';
+import useToast from '@/common-ui/Toast/hooks/useToast';
 
 const DOMAIN = 'COMMENT';
 
@@ -78,11 +79,11 @@ const postCommentAPI = async ({
 };
 
 export interface POSTCommentQueryRequest {
-  memberId: number;
+  bookmarkId: string;
   initComment: () => void;
 }
 export const usePOSTCommentQuery = ({
-  memberId,
+  bookmarkId,
   initComment,
 }: POSTCommentQueryRequest) => {
   const queryClient = useQueryClient();
@@ -90,7 +91,7 @@ export const usePOSTCommentQuery = ({
     onSuccess: () => {
       queryClient.invalidateQueries(
         GET_BOOKMARK_COMMENT({
-          memberId,
+          bookmarkId,
         }),
       );
       initComment();
@@ -133,11 +134,11 @@ const putCommentAPI = async ({
 };
 
 export interface PUTCommentQueryRequest {
-  memberId: number;
+  bookmarkId: string;
   initComment: () => void;
 }
 export const usePUTCommentQuery = ({
-  memberId,
+  bookmarkId,
   initComment,
 }: PUTCommentQueryRequest) => {
   const queryClient = useQueryClient();
@@ -145,7 +146,7 @@ export const usePUTCommentQuery = ({
     onSuccess: () => {
       queryClient.invalidateQueries(
         GET_BOOKMARK_COMMENT({
-          memberId,
+          bookmarkId,
         }),
       );
       initComment();
@@ -172,19 +173,21 @@ const deleteCommentAPI = async ({ commentId, token }: DELETECommentRequest) => {
 };
 
 export interface DELETECommentQueryRequest {
-  memberId: number;
+  bookmarkId: string;
 }
 export const useDELETECommentQuery = ({
-  memberId,
+  bookmarkId,
 }: DELETECommentQueryRequest) => {
   const queryClient = useQueryClient();
+  const { fireToast } = useToast();
   return useMutation(deleteCommentAPI, {
     onSuccess: () => {
       queryClient.invalidateQueries(
         GET_BOOKMARK_COMMENT({
-          memberId,
+          bookmarkId,
         }),
       );
+      fireToast({ message: '삭제 되었습니다', mode: 'DELETE' });
     },
   });
 };

--- a/src/comment/ui/bookmark/BlankComment.tsx
+++ b/src/comment/ui/bookmark/BlankComment.tsx
@@ -1,0 +1,49 @@
+import Text from '@/common-ui/Text';
+import Icon from '@/common-ui/assets/Icon';
+import { theme } from '@/styles/theme';
+import getRem from '@/utils/getRem';
+import styled from '@emotion/styled';
+
+const BlankComment = () => {
+  return (
+    <Container>
+      <IconWrapper>
+        <Icon name="circle-pencil" size="l" />
+      </IconWrapper>
+      <TextWrapper>
+        <BlankText fontSize={0.8} weight="bold">
+          댓글이 없습니다.
+        </BlankText>
+        <BlankText fontSize={0.8} weight="bold">
+          첫 댓글을 남겨보세요!
+        </BlankText>
+      </TextWrapper>
+    </Container>
+  );
+};
+
+export default BlankComment;
+
+const Container = styled.div`
+  display: grid;
+  flex-direction: column;
+  row-gap: 0.6rem;
+  padding: ${getRem(15, 20)};
+  border-radius: ${getRem(7)};
+  background-color: ${theme.colors.grey800};
+  margin-bottom: 1rem;
+`;
+
+const IconWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  row-gap: 0.2rem;
+  align-items: center;
+`;
+
+const BlankText = styled(Text.Span)``;

--- a/src/comment/ui/bookmark/CommentList.tsx
+++ b/src/comment/ui/bookmark/CommentList.tsx
@@ -1,5 +1,4 @@
 import { useGETBookmarkCommentListQuery } from '@/bookmarks/api/bookmark';
-import useAuthStore from '@/store/auth';
 import CommentItem from './CommentItem';
 import styled from '@emotion/styled';
 import { timeStampToDate } from '@/utils/date/timeConverter';
@@ -7,14 +6,16 @@ import useCommentStore from '@/store/comment';
 import { useDELETECommentQuery } from '@/comment/api/Comment';
 import BSConfirmation from '@/common/ui/BSConfirmation';
 import useBottomSheet from '@/common-ui/BottomSheet/hooks/useBottomSheet';
+import { useParams } from 'react-router-dom';
+import BlankComment from './BlankComment';
 
 const CommentList = () => {
   // FIRST RENDER
-  const { userInfo } = useAuthStore();
   const { comment, setCommentId, setCommentCount } = useCommentStore();
   // SERVER
+  const { id: bookmarkId } = useParams<{ id: string }>();
   const { data: commentList } = useGETBookmarkCommentListQuery({
-    memberId: userInfo?.id ?? '',
+    bookmarkId: bookmarkId ?? '',
     setCommentCount,
   });
 
@@ -24,7 +25,7 @@ const CommentList = () => {
 
   // 2. 댓글 삭제
   const { mutate: deleteComment } = useDELETECommentQuery({
-    memberId: userInfo?.id ?? '',
+    bookmarkId: bookmarkId ?? '',
   });
   const onClickDeleteComment = () => {
     deleteComment({ commentId: comment.id ?? 0 });
@@ -38,6 +39,7 @@ const CommentList = () => {
 
   return (
     <CommentListWrapper>
+      {!commentList?.length && <BlankComment />}
       {commentList?.map((comment) => (
         <CommentItem
           key={comment.id}

--- a/src/comment/ui/bookmark/CommentUploadInput.tsx
+++ b/src/comment/ui/bookmark/CommentUploadInput.tsx
@@ -13,6 +13,7 @@ const CommentUploadInput = () => {
   const { memberId } = useAuthStore();
   const { id } = useParams() as { id: string };
   const { mode, comment, setComment, initComment } = useCommentStore();
+  const { id: bookmarkId } = useParams<{ id: string }>();
 
   const onChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     const { value } = event.target;
@@ -24,10 +25,13 @@ const CommentUploadInput = () => {
   };
 
   const { mutate: postComment } = usePOSTCommentQuery({
-    memberId,
+    bookmarkId: bookmarkId ?? '',
     initComment,
   });
-  const { mutate: editComment } = usePUTCommentQuery({ memberId, initComment });
+  const { mutate: editComment } = usePUTCommentQuery({
+    bookmarkId: bookmarkId ?? '',
+    initComment,
+  });
 
   const onSubmit = (
     event: React.FormEvent<HTMLFormElement> | MouseEvent<HTMLButtonElement>,


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #157
- PR의 메인 내용

1. 북마크 게시물 관련 댓글로 불러오도록 수정
2. 댓글이 없는 경우 UI 추가

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] 자신의 전체 댓글 게시물 > 게시물 관련 댓글 API로 변경
- [x] BlankComment UI 컴포넌트 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
