### PR TITLE
fix: 내 포스트가 아니면 좋아요/해제 누를 수 없도록 설정

### DIFF
--- a/src/bookmarks/ui/BookmarkArticle.tsx
+++ b/src/bookmarks/ui/BookmarkArticle.tsx
@@ -57,11 +57,15 @@ const BookMarkArticle = ({
     memberId,
   });
 
+  const isMyPost = bookmarkDetail?.memberId === memberId;
+
   const onClickLike = () => {
+    if (!isMyPost) return;
     postBookmarkLike({ bookmarkId: bookmarkId ?? '' });
   };
 
   const onClickDislike = () => {
+    if (!isMyPost) return;
     postBookmarkDislike({ bookmarkId: bookmarkId ?? '' });
   };
 
@@ -154,6 +158,7 @@ const BookMarkArticle = ({
           <LikeAndMessageIconWrapper>
             <BookmarkLikeButton
               isLike={bookmarkDetail?.isUserLike ?? false}
+              isMyPost={isMyPost}
               onClickLike={onClickLike}
               onClickDislike={onClickDislike}
             />

--- a/src/bookmarks/ui/Like/BookmarkLikeButton.tsx
+++ b/src/bookmarks/ui/Like/BookmarkLikeButton.tsx
@@ -4,12 +4,14 @@ import styled from '@emotion/styled';
 
 interface BookMarkLikeButtonProps {
   isLike: boolean;
+  isMyPost?: boolean;
   onClickLike?: () => void;
   onClickDislike?: () => void;
 }
 
 const BookmarkLikeButton = ({
   isLike,
+  isMyPost = true,
   onClickLike,
   onClickDislike,
 }: BookMarkLikeButtonProps) => {
@@ -18,6 +20,7 @@ const BookmarkLikeButton = ({
       onClick={() => {
         isLike ? onClickDislike?.() : onClickLike?.();
       }}
+      disabled={!isMyPost}
     >
       {isLike ? (
         <Icon name="heart-fill-green" size="m" />
@@ -30,10 +33,14 @@ const BookmarkLikeButton = ({
 
 export default BookmarkLikeButton;
 
-const LikeButton = styled.button`
+interface LikeButtonProps {
+  disabled: boolean;
+}
+
+const LikeButton = styled.button<LikeButtonProps>`
   width: ${getRem(40)};
   height: 100%;
   &:active {
-    opacity: 0.5;
+    opacity: ${({ disabled }) => (disabled ? 1 : 0.5)};
   }
 `;


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #161
- PR의 메인 내용

1. 내 포스트가 아니면 좋아요/해제 누를 수 없도록 설정

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] 북마크 상세 페이지 memberId와 로그인 id 판별하여 내 포스트 판단
- [x] css 수정

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
