### PR TITLE
fix: 친구 리스트 페이지 닉네임 제대로 출력되지 않는 오류 수정

### DIFF
--- a/src/friend/api/friends.tsx
+++ b/src/friend/api/friends.tsx
@@ -17,7 +17,7 @@ export interface GETFollowingListResponse {
 }
 export interface FollowingInfo {
   memberId: number;
-  loginId: string;
+  nickname: string;
   emoji: string;
 }
 
@@ -78,7 +78,7 @@ export const useGETFollowingListQuery = (
 // 팔로워 리스트 API
 interface FollowerInfo {
   memberId: number;
-  loginId: string;
+  nickname: string;
   isFollowing: boolean;
   emoji: string;
 }

--- a/src/friend/ui/Friends.tsx
+++ b/src/friend/ui/Friends.tsx
@@ -50,7 +50,7 @@ const Friends = () => {
               key={info.memberId}
               id={info.memberId}
               memberId={memberId}
-              name={info.loginId}
+              name={info.nickname}
               profileEmoji={info.emoji}
               isFollowing={true}
             />
@@ -64,7 +64,7 @@ const Friends = () => {
               key={info.memberId}
               id={info.memberId}
               memberId={memberId}
-              name={info.loginId}
+              name={info.nickname}
               profileEmoji={info.emoji}
               isFollowing={info.isFollowing}
             />


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #169
- PR의 메인 내용

1. 팔로워 리스트 닉네임 제대로 나오도록 수정
2. 팔로잉 리스트 닉네임 제대로 나오도록 수정

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] loginId -> nickname 필드로 변경

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
