### PR TITLE
fix: 차단 유저 목록 조회 실 API 연동 및 목록 없음에 대한 이미지와 텍스트 추가

### DIFF
--- a/src/common-ui/BlankItem.tsx
+++ b/src/common-ui/BlankItem.tsx
@@ -11,7 +11,8 @@ type PAGE =
   | 'FOLLOWER'
   | 'FOLLOWING'
   | 'COMMENT'
-  | 'LIKE';
+  | 'LIKE'
+  | 'BLOCK_USER';
 
 interface BlankItemProps {
   page: PAGE;
@@ -27,6 +28,7 @@ const description: Record<BlankItemProps['page'], string> = {
   FOLLOWING: '앗! 아직 팔로잉 중인\n 친구가 없어요',
   COMMENT: '앗! 아직 댓글이 없어요',
   LIKE: '아직 좋아요를\n 누르지 않았어요!',
+  BLOCK_USER: '차단한 사용자가 없어요',
 };
 
 const height: Record<BlankItemProps['page'], string> = {
@@ -39,6 +41,7 @@ const height: Record<BlankItemProps['page'], string> = {
   FOLLOWING: 'calc(80dvh - 5rem)',
   COMMENT: 'calc(100dvh - 10rem)',
   LIKE: 'calc(100dvh - 10rem)',
+  BLOCK_USER: 'calc(100dvh - 5rem)',
 };
 
 const imgSrc: Record<BlankItemProps['page'], string> = {
@@ -51,6 +54,7 @@ const imgSrc: Record<BlankItemProps['page'], string> = {
   FOLLOWING: '/images/empty.png',
   COMMENT: '/images/empty.png',
   LIKE: '/images/empty.png',
+  BLOCK_USER: '/images/empty.png',
 };
 
 const BlankItem = ({ page }: BlankItemProps) => {

--- a/src/members/ui/BlockMemberList.tsx
+++ b/src/members/ui/BlockMemberList.tsx
@@ -7,6 +7,7 @@ import getRem from '@/utils/getRem';
 import { theme } from '@/styles/theme';
 import useBottomIntersection from '@/common/service/hooks/useBottomIntersection';
 import MemberSkeleton from './MemberSkeleton';
+import BlankItem from '@/common-ui/BlankItem';
 
 const BlockMemberList = () => {
   // FIRST RENDER
@@ -37,11 +38,12 @@ const BlockMemberList = () => {
 
   return (
     <Wrapper>
+      {!flatBlockMemberList.length && <BlankItem page="BLOCK_USER" />}
       {flatBlockMemberList.map((info) => (
         <Member
           key={info.id}
           emoji={info.profileEmoji}
-          name={info.name}
+          name={info.nickname}
           button={
             <StyledButton
               onClick={() => onClick(info.id)}

--- a/src/pages/FriendBookmarkPage.tsx
+++ b/src/pages/FriendBookmarkPage.tsx
@@ -34,7 +34,7 @@ const FriendBookmarkPage = () => {
 
   // USER INTERACTION
   // 1. 상단 more > 차단하기
-  const { mutate: postBlockMember } = usePOSTBlockMemberQuery();
+  const { mutate: postBlockMember } = usePOSTBlockMemberQuery({ memberId });
   const onClick_차단하기 = () => {
     postBlockMember({ blockeeId: Number(friendId), blockerId: memberId });
   };


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #171
- PR의 메인 내용

1.  차단 유저 목록 API 연동
2. 차단 유저 목록 없음 UI 추가

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] 차단 유저 목록 조회 실 API 연동 및 관련 query update 추가
- [x] 차단 유저 목록 없음에 대한 BlankItem 필드 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
