### PR TITLE
[FIX] 댓글리스트 내, 북마크 조회시 북마크 id의 맵핑작업을 재진행합니다.

### DIFF
--- a/src/comment/api/Comment.ts
+++ b/src/comment/api/Comment.ts
@@ -15,6 +15,7 @@ export const GET_COMMENT_LIST = [getKeyofObject(navigatePath, '/'), DOMAIN];
 interface ServerCommentItem {
   id: number;
   member: string;
+  bookmarkId: number;
   bookmark: string;
   category: string;
   isOwnerComment: boolean;

--- a/src/comment/ui/comment-list/CommentItem.tsx
+++ b/src/comment/ui/comment-list/CommentItem.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from 'react-router-dom';
 
 interface CommentListProps {
   id: number;
+  bookmarkId: number;
   title: string;
   nickName: string;
   content: string;
@@ -18,6 +19,7 @@ interface CommentListProps {
 
 const CommentItem = ({
   id,
+  bookmarkId,
   title,
   nickName,
   content,
@@ -27,7 +29,7 @@ const CommentItem = ({
   const navigate = useNavigate();
 
   const navigateToBookmark = () => {
-    navigate(navigatePath.BOOKMARK_DETAIL.replace(':id', String(id)));
+    navigate(navigatePath.BOOKMARK_DETAIL.replace(':id', String(bookmarkId)));
   };
 
   return (

--- a/src/pages/CommentPage.tsx
+++ b/src/pages/CommentPage.tsx
@@ -24,6 +24,7 @@ const CommentPage = () => {
               <CommentItem
                 key={comment.id} // 변경이 되었는지 안되었는지 판단 여부
                 id={comment.id}
+                bookmarkId={comment.bookmarkId}
                 title={comment.bookmark}
                 content={comment.content}
                 nickName={comment.member}


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #200 
- PR의 메인 내용
- Bookmark Id를 통해 onClick 메서드가 실행되도록 수정 

<br>