### PR TITLE
fix: 유저 차단/해제에 대해서 상태가 제대로 업데이트 되지 않던 오류 수정

### DIFF
--- a/src/bookmarks/ui/BookmarkUserInfo.tsx
+++ b/src/bookmarks/ui/BookmarkUserInfo.tsx
@@ -13,6 +13,7 @@ interface BookmarkUserInfoProps {
     isFollowing: boolean;
     friendId: number;
     memberId: number;
+    isBlocked: boolean;
   };
 }
 
@@ -43,12 +44,14 @@ const BookmarkUserInfo = ({
             <UnFollowButton
               followerId={isFriendPage.memberId}
               memberId={isFriendPage.friendId}
+              isBlocked={isFriendPage.isBlocked}
             />
           )}
           {!isFriendPage?.isFollowing && (
             <FollowButton
               followerId={isFriendPage.memberId}
               memberId={isFriendPage.friendId}
+              isBlocked={isFriendPage.isBlocked}
             />
           )}
         </>

--- a/src/friend/api/friends.tsx
+++ b/src/friend/api/friends.tsx
@@ -20,6 +20,7 @@ export interface FollowingInfo {
   memberId: number;
   nickname: string;
   emoji: string;
+  isBlocked: boolean;
 }
 
 interface GETFollowingListRequest {
@@ -81,6 +82,7 @@ interface FollowerInfo {
   memberId: number;
   nickname: string;
   isFollowing: boolean;
+  isBlocked: boolean;
   emoji: string;
 }
 
@@ -392,6 +394,7 @@ export interface SearchList {
   nickname: string;
   emoji: string;
   isFollowing: boolean;
+  isBlocked: boolean;
 }
 
 interface GETSearchListRequest {
@@ -431,8 +434,6 @@ export const GET_SEARCH_LIST_KEY = (params: GETSearchListQueryRequest) => [
   'GET_SEARCH_LIST',
   params.memberId,
   params.keyword,
-  params.cursorId,
-  params.pageSize,
 ];
 
 export const useGETSearchListQuery = (params: GETSearchListQueryRequest) => {

--- a/src/friend/ui/Friends.tsx
+++ b/src/friend/ui/Friends.tsx
@@ -51,6 +51,7 @@ const Friends = () => {
               name={info.nickname}
               profileEmoji={info.emoji}
               isFollowing={true}
+              isBlocked={info.isBlocked}
             />
           ))}
         {selectedType === FriendType.Following && !followings.length && (
@@ -65,6 +66,7 @@ const Friends = () => {
               name={info.nickname}
               profileEmoji={info.emoji}
               isFollowing={info.isFollowing}
+              isBlocked={info.isBlocked}
             />
           ))}
       </Container>

--- a/src/friend/ui/buttons/FollowButton.tsx
+++ b/src/friend/ui/buttons/FollowButton.tsx
@@ -6,18 +6,34 @@ import { theme } from '@/styles/theme';
 import { type MouseEvent } from 'react';
 import { usePOSTFollowUserQuery } from '@/friend/api/friends';
 import useSearchStore from '@/store/search';
+import useToast from '@/common-ui/Toast/hooks/useToast';
 
 interface FollowButtonProps {
   memberId: number;
   followerId: number;
+  isBlocked?: boolean;
 }
-const FollowButton = ({ memberId, followerId }: FollowButtonProps) => {
+const FollowButton = ({
+  memberId,
+  followerId,
+  isBlocked = false,
+}: FollowButtonProps) => {
   const { setSelectedMemberId } = useSearchStore();
   const { mutate } = usePOSTFollowUserQuery({ memberId: followerId });
+
+  const { fireToast } = useToast();
 
   //TODO: 하드 코딩 개선
   const onClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
+    if (isBlocked) {
+      fireToast({
+        message: '차단된 사용자는 팔로우 할 수 없어요',
+        mode: 'ERROR',
+      });
+      return;
+    }
+
     setSelectedMemberId(memberId);
     mutate({ memberId, followerId });
   };

--- a/src/friend/ui/buttons/UnFollowButton.tsx
+++ b/src/friend/ui/buttons/UnFollowButton.tsx
@@ -5,18 +5,32 @@ import { theme } from '@/styles/theme';
 import { type MouseEvent } from 'react';
 import { useDELETEUnFollowQuery } from '@/friend/api/friends';
 import useSearchStore from '@/store/search';
+import useToast from '@/common-ui/Toast/hooks/useToast';
 
 interface UnFollowButtonProps {
   memberId: number;
   followerId: number;
+  isBlocked?: boolean;
 }
-const UnFollowButton = ({ memberId, followerId }: UnFollowButtonProps) => {
+const UnFollowButton = ({
+  memberId,
+  followerId,
+  isBlocked = false,
+}: UnFollowButtonProps) => {
   const { setSelectedMemberId } = useSearchStore();
   const { mutate } = useDELETEUnFollowQuery({ memberId: followerId });
 
-  //TODO: 하드코딩 개선
+  const { fireToast } = useToast();
+
   const onClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
+    if (isBlocked) {
+      fireToast({
+        message: '차단된 사용자는 팔로우 할 수 없어요',
+        mode: 'ERROR',
+      });
+      return;
+    }
     setSelectedMemberId(memberId);
     mutate({ memberId, followerId });
   };

--- a/src/friend/ui/friend/FriendFollowerItem.tsx
+++ b/src/friend/ui/friend/FriendFollowerItem.tsx
@@ -8,6 +8,7 @@ type FriendFollowerProps = {
   name: string;
   profileEmoji: string;
   isFollowing: boolean;
+  isBlocked: boolean;
 };
 const FriendFollowerItem = ({
   id,
@@ -15,6 +16,7 @@ const FriendFollowerItem = ({
   name,
   profileEmoji,
   isFollowing,
+  isBlocked,
 }: FriendFollowerProps) => {
   return (
     <FriendItemLayout
@@ -23,9 +25,17 @@ const FriendFollowerItem = ({
       emoji={profileEmoji}
       button={
         isFollowing ? (
-          <UnFollowButton followerId={memberId} memberId={id} />
+          <UnFollowButton
+            followerId={memberId}
+            memberId={id}
+            isBlocked={isBlocked}
+          />
         ) : (
-          <FollowButton followerId={memberId} memberId={id} />
+          <FollowButton
+            followerId={memberId}
+            memberId={id}
+            isBlocked={isBlocked}
+          />
         )
       }
     />

--- a/src/friend/ui/friend/FriendFollowingItem.tsx
+++ b/src/friend/ui/friend/FriendFollowingItem.tsx
@@ -8,6 +8,7 @@ type FriendFollowingProps = {
   name: string;
   profileEmoji: string;
   isFollowing: boolean;
+  isBlocked: boolean;
 };
 const FriendFollowingItem = ({
   id,
@@ -15,6 +16,7 @@ const FriendFollowingItem = ({
   name,
   profileEmoji,
   isFollowing,
+  isBlocked,
 }: FriendFollowingProps) => {
   return (
     <FriendItemLayout
@@ -23,9 +25,17 @@ const FriendFollowingItem = ({
       id={id}
       button={
         isFollowing ? (
-          <UnFollowButton memberId={id} followerId={memberId} />
+          <UnFollowButton
+            memberId={id}
+            followerId={memberId}
+            isBlocked={isBlocked}
+          />
         ) : (
-          <FollowButton memberId={id} followerId={memberId} />
+          <FollowButton
+            memberId={id}
+            followerId={memberId}
+            isBlocked={isBlocked}
+          />
         )
       }
     />

--- a/src/friend/ui/friend/FriendList.tsx
+++ b/src/friend/ui/friend/FriendList.tsx
@@ -40,7 +40,8 @@ const FriendList = ({ keyword }: FriendListProps) => {
             memberId={memberId}
             name={info.nickname}
             profileEmoji={info.emoji}
-            isFollowing={Boolean(info.isFollowing)}
+            isFollowing={info.isFollowing}
+            isBlocked={info.isBlocked}
           />
         ))}
       </Container>

--- a/src/pages/FriendBookmarkPage.tsx
+++ b/src/pages/FriendBookmarkPage.tsx
@@ -13,17 +13,25 @@ import IconButton from '@/common/ui/IconButton';
 import {
   useGETFriendProfileQuery,
   usePOSTBlockMemberQuery,
+  useUnblockUserQuery,
 } from '@/members/api/member';
 import useAuthStore from '@/store/auth';
 import BookmarkListView from '@/bookmarks/ui/Main/BookmarkListView';
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
 import SkeletonWrapper from '@/common-ui/SkeletonWrapper';
 import BookmarkSkeletonItem from '@/bookmarks/ui/Main/BookmarkSkeletonItem';
+import useFriendStore from '@/store/friend';
 
 const FriendBookmarkPage = () => {
   // FIRST RENDER
   const { memberId } = useAuthStore();
   const { id: friendId } = useParams<{ id: string }>();
+
+  const { setFriendId } = useFriendStore();
+
+  useEffect(() => {
+    setFriendId(Number(friendId));
+  }, [friendId]);
 
   // SERVER
   // 1. 친구 프로필 조회
@@ -37,6 +45,10 @@ const FriendBookmarkPage = () => {
   const { mutate: postBlockMember } = usePOSTBlockMemberQuery({ memberId });
   const onClick_차단하기 = () => {
     postBlockMember({ blockeeId: Number(friendId), blockerId: memberId });
+  };
+  const { mutate: deleteUnBlockMember } = useUnblockUserQuery({ memberId });
+  const onClick_차단해제 = () => {
+    deleteUnBlockMember({ blockeeId: Number(friendId), blockerId: memberId });
   };
 
   // 2. 카테고리 선택
@@ -59,21 +71,29 @@ const FriendBookmarkPage = () => {
               as={<IconButton onClick={() => {}} name="more" size="s" />}
             />
             <TriggerBottomSheet.BottomSheet>
-              <TriggerBottomSheet.Item onClick={onClick_차단하기}>
-                차단하기
-              </TriggerBottomSheet.Item>
+              {!!profileInfo?.isBlocked && (
+                <TriggerBottomSheet.Item onClick={onClick_차단해제}>
+                  차단해제
+                </TriggerBottomSheet.Item>
+              )}
+              {!profileInfo?.isBlocked && (
+                <TriggerBottomSheet.Item onClick={onClick_차단하기}>
+                  차단하기
+                </TriggerBottomSheet.Item>
+              )}
             </TriggerBottomSheet.BottomSheet>
           </TriggerBottomSheet>
         }
       />
       <LTop>
         <BookmarkUserInfo
-          userEmoji={profileInfo?.profileEmoji || ''}
-          userName={profileInfo?.nickname || ''}
+          userEmoji={profileInfo?.profileEmoji ?? ''}
+          userName={profileInfo?.nickname ?? ''}
           isFriendPage={{
-            isFollowing: profileInfo?.isFollowing || false,
+            isFollowing: profileInfo?.isFollowing ?? false,
             friendId: Number(friendId),
             memberId,
+            isBlocked: profileInfo?.isBlocked ?? false,
           }}
         />
       </LTop>

--- a/src/store/friend.ts
+++ b/src/store/friend.ts
@@ -8,12 +8,18 @@ export enum FriendType {
 interface FriendStore {
   selectedType: FriendType;
   setSelectedType: (mode: FriendType) => void;
+  friendId: number;
+  setFriendId: (friendId: number) => void;
 }
 
 const useFriendStore = create<FriendStore>((set) => ({
   selectedType: FriendType.Follower,
   setSelectedType: (selectedType) => {
     set({ selectedType });
+  },
+  friendId: 0,
+  setFriendId: (friendId) => {
+    set({ friendId });
   },
 }));
 

--- a/src/store/toast.ts
+++ b/src/store/toast.ts
@@ -9,7 +9,8 @@ export type ToastMessage =
   | '앗! 유효하지 않은 주소에요'
   | '신고 되었습니다'
   | '이미 신고한 북마크에요'
-  | '앗! 알림 설정 기준일은 1일 이상이어야 해요';
+  | '앗! 알림 설정 기준일은 1일 이상이어야 해요'
+  | '차단된 사용자는 팔로우 할 수 없어요';
 
 export type ToastMode = 'SUCCESS' | 'DELETE' | 'ERROR';
 


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #203
- PR의 메인 내용

1. 차단후 유저 프로필 업데이트
2. 차단후 검색에서 팔로우 금지
3. 친구 상세 페이지 차단 여부 변경

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] 차단 / 해제 관련 query update
- [x] 차단시 팔로우 못하도록 toast 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
