### PR TITLE
fix: 알림 리스트 세로 방향 스크롤 오류 수정

### DIFF
--- a/src/notification/ui/Notifications.tsx
+++ b/src/notification/ui/Notifications.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/notification/api/notification';
 import useAuthStore from '@/store/auth';
 import BlankItem from '@/common-ui/BlankItem';
+import styled from '@emotion/styled';
 
 const Notifications = () => {
   // FIRST RENDER
@@ -33,7 +34,7 @@ const Notifications = () => {
   };
 
   return (
-    <>
+    <Wrapper>
       {notificationList?.length === 0 && <BlankItem page="NOTIFICATION" />}
       {notificationList?.map((notification) => (
         <NotificationSlideItem
@@ -51,8 +52,12 @@ const Notifications = () => {
           deleteNotification={() => onClickDeleteNotification(notification.id)}
         />
       ))}
-    </>
+    </Wrapper>
   );
 };
 
 export default Notifications;
+
+const Wrapper = styled.div`
+  padding-bottom: 5rem;
+`;

--- a/src/pages/NotificationPage.tsx
+++ b/src/pages/NotificationPage.tsx
@@ -2,15 +2,20 @@ import { Suspense } from 'react';
 import Header from '@/common-ui/Header/Header';
 import NotificationSkeletonItem from '@/notification/ui/NotificationSkeletonItem';
 import Notifications from '@/notification/ui/Notifications';
+import SkeletonWrapper from '@/common-ui/SkeletonWrapper';
 
 const NotificationPage = () => {
   return (
     <>
       <Header title={'🔔 알림 왔어요!'} />
       <Suspense
-        fallback={[1, 2, 3].map((item) => (
-          <NotificationSkeletonItem key={item} />
-        ))}
+        fallback={
+          <SkeletonWrapper>
+            {Array.from({ length: 5 }).map((_, index) => (
+              <NotificationSkeletonItem key={index} />
+            ))}
+          </SkeletonWrapper>
+        }
       >
         <Notifications />
       </Suspense>


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #236
- PR의 메인 내용

1. 알림 리스트 세로 방향 스크롤 오류 수정
2. BottomNavigation에 가리지 않도록 padding 적용

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] SlideItem 세로 스크롤 이벤트 막기
- [x] Notifications padding 적용

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
