### PR TITLE
fix: 헤더 sticky 적용 안되던 오류 수정, 스크롤 유지 되도록 수정

### DIFF
--- a/src/bookmarks/service/hooks/home/useBookmarkList.tsx
+++ b/src/bookmarks/service/hooks/home/useBookmarkList.tsx
@@ -23,7 +23,7 @@ const useBookmarkList = ({
     isLoading,
     fetchNextPage,
     isFetchingNextPage,
-    remove,
+    refetch,
   } = useGETBookMarkListQuery({
     readByUser,
     categoryId,
@@ -31,14 +31,14 @@ const useBookmarkList = ({
   });
 
   useEffect(() => {
-    if (categoryId) remove();
+    if (categoryId) refetch();
   }, [categoryId]);
 
   const { initializeUrlAndTitle } = useBookmarkStore();
 
   useEffect(() => {
     initializeUrlAndTitle();
-    remove();
+    refetch();
   }, [navigate]);
 
   return {

--- a/src/common-ui/Layout.tsx
+++ b/src/common-ui/Layout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 import styled from '@emotion/styled';
 import BottomNavigation from '@/common-ui/BottomNavigation';
 import { navigatePath, NavigatePath } from '@/constants/navigatePath';
@@ -17,9 +17,43 @@ const Layout = ({ children }: { children: ReactNode }) => {
     pathname as NavigatePath,
   );
 
+  const ref = useRef<HTMLDivElement>(null);
+
+  const loadScroll = () => {
+    const scroll = sessionStorage.getItem('scroll');
+    if (scroll && ref.current && pathname === '/') {
+      ref.current?.scrollTo({
+        top: Number(scroll),
+        behavior: 'instant',
+      });
+    }
+  };
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (ref.current && ref.current.scrollTop > 0) {
+        sessionStorage.setItem('scroll', ref.current.scrollTop.toString());
+      }
+    };
+
+    if (ref.current && pathname === '/') {
+      ref.current.addEventListener('scroll', handleScroll);
+    }
+
+    return () => {
+      if (ref.current && pathname === '/') {
+        ref.current.removeEventListener('scroll', handleScroll);
+      }
+    };
+  }, [pathname]);
+
+  useEffect(() => {
+    loadScroll();
+  }, [pathname]);
+
   return (
     <LayoutContainer>
-      <InnerWrapper>{children}</InnerWrapper>
+      <InnerWrapper ref={ref}>{children}</InnerWrapper>
       {isShowBottomNavigation && <BottomNavigation />}
     </LayoutContainer>
   );
@@ -31,7 +65,6 @@ const LayoutContainer = styled.div`
   position: relative;
   max-width: 480px;
   margin: 0 auto;
-  overflow: hidden;
 `;
 
 const InnerWrapper = styled.div`

--- a/src/common-ui/PullToRefresh.tsx
+++ b/src/common-ui/PullToRefresh.tsx
@@ -75,7 +75,6 @@ const PullToRefresh = ({
       onTouchStart={onTouchStart}
       onTouchEnd={onTouchEnd}
       onTouchMove={onTouchMove}
-      style={{ overflow: 'hidden' }}
     >
       <IconContainer
         style={{
@@ -110,6 +109,7 @@ const IconContainer = styled.div`
   z-index: 10;
   top: 0;
   transition: transform 0.3s;
+  background-color: ${theme.colors.black};
 `;
 
 const fade = keyframes`


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #276
- PR의 메인 내용

1. 헤더 sticky 동작 하도록 수정
2. 스크롤 유지 추가

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] PullToRefresh overflow hidden 제거
- [x] 스크롤 유지 되도록 Layout에 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
