### PR TITLE
fix: 북마크 상세 페이지 스크롤 위치 top으로 고정

### DIFF
--- a/src/comment/api/Comment.ts
+++ b/src/comment/api/Comment.ts
@@ -3,12 +3,14 @@ import client from '@/common/service/client';
 import { navigatePath } from '../../constants/navigatePath';
 import {
   GET_BOOKMARK_COMMENT,
+  GET_BOOKMARK_LIST,
   refetchAllBookmarkQuery,
 } from '@/bookmarks/api/bookmark';
 import useToast from '@/common-ui/Toast/hooks/useToast';
 import { useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import useAuthStore from '@/store/auth';
+import useBookmarkStore from '@/store/bookmark';
 
 const DOMAIN = 'COMMENT';
 
@@ -96,6 +98,7 @@ export const usePOSTCommentQuery = ({
 }: POSTCommentQueryRequest) => {
   const queryClient = useQueryClient();
   const { memberId } = useAuthStore();
+  const { readOption, selectedCategoryId } = useBookmarkStore();
   return useMutation(postCommentAPI, {
     onSuccess: () => {
       queryClient.refetchQueries(
@@ -105,6 +108,9 @@ export const usePOSTCommentQuery = ({
         }),
       );
       refetchAllBookmarkQuery({ queryClient, memberId, bookmarkId });
+      queryClient.invalidateQueries(
+        GET_BOOKMARK_LIST(memberId, readOption, selectedCategoryId),
+      );
       initComment();
     },
   });

--- a/src/common-ui/Layout.tsx
+++ b/src/common-ui/Layout.tsx
@@ -30,6 +30,15 @@ const Layout = ({ children }: { children: ReactNode }) => {
   };
 
   useEffect(() => {
+    if (ref.current && pathname.includes('bookmark')) {
+      ref.current.scrollTo({
+        top: 0,
+        behavior: 'instant',
+      });
+    }
+  }, [pathname]);
+
+  useEffect(() => {
     const handleScroll = () => {
       if (ref.current && ref.current.scrollTop > 0) {
         sessionStorage.setItem('scroll', ref.current.scrollTop.toString());


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #278
- PR의 메인 내용

1. 북마크 상세 페이지 스크롤 오류 수정

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] layout에서 북마크 상세 페이지 스크롤 top으로 고정

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
