### PR TITLE
Fix/#292/category delete error

### DIFF
--- a/src/category/api/delete.ts
+++ b/src/category/api/delete.ts
@@ -1,9 +1,9 @@
 import client from '@/common/service/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { GET_CATEGORY_LIST } from './category';
-import { GET_BOOKMARK_CATEGORY_LIST } from '@/bookmarks/api/bookmark';
 import qs from 'qs';
 import useToast from '@/common-ui/Toast/hooks/useToast';
+import { GET_BOOKMARK_LIST } from '@/bookmarks/api/bookmark';
 interface DeleteCategoryRequest {
   memberId: number;
   categoryId: string[];
@@ -31,10 +31,15 @@ export const useDeleteCategoryMutation = ({
 }: DeleteCategoryMutation) => {
   const queryClient = useQueryClient();
   const toast = useToast();
+
   return useMutation(DeleteCategory.API, {
     onSuccess: async () => {
       await queryClient.refetchQueries(GET_CATEGORY_LIST(memberId));
-      queryClient.refetchQueries(GET_BOOKMARK_CATEGORY_LIST(memberId));
+      queryClient.invalidateQueries(GET_BOOKMARK_LIST(memberId, '📖 전체', 0));
+      queryClient.invalidateQueries(GET_BOOKMARK_LIST(memberId, '👀 읽음', 0));
+      queryClient.invalidateQueries(
+        GET_BOOKMARK_LIST(memberId, '🫣 읽지 않음', 0),
+      );
       toast.fireToast({
         message: '삭제 되었습니다',
         mode: 'DELETE',

--- a/src/pages/UserInfoPage.tsx
+++ b/src/pages/UserInfoPage.tsx
@@ -70,7 +70,7 @@ const UserInfoPage = ({ mode }: UserCreatePageProps) => {
     setDisabled(false);
   }, [name, nickname, emoji, initialValues]);
 
-  const { mutate } = usePutUserInfoQuery({ mode: 'CREATE', memberId });
+  const { mutate } = usePutUserInfoQuery({ mode, memberId });
 
   const onSubmitUserInfo: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #292
- PR의 메인 내용

1. 카테고리 삭제 후 북마크 남아있는 오류 수정
2. 유저 프로필 수정 후 프로필 페이지로 안가는 오류 수정

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] 카테고리 삭제 -> 리스트 query invalidate
- [x] 유저 프로필 모드 수정

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
