### PR TITLE
fix: 공개 범위선택 가려지던 오류 및 20개 이상 추가 시 toast 추가

### DIFF
--- a/src/bookmarks/ui/BookmarkTagList.tsx
+++ b/src/bookmarks/ui/BookmarkTagList.tsx
@@ -5,7 +5,9 @@ import getRem, { calculateRem } from '@/utils/getRem';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { ClientBookmarkCategoryItem } from '../api/bookmark';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import useToast from '@/common-ui/Toast/hooks/useToast';
+import { MAX_CATEGORY_COUNT } from '@/store/bookmark';
 
 interface TagBoxListProps {
   tags: ClientBookmarkCategoryItem[];
@@ -28,7 +30,7 @@ const TagBoxList = ({
           onClickCategory={onClickCategory}
         />
       ))}
-      <PlusBox to="/category/add" />
+      <PlusBox to="/category/add" categoryCount={tags.length} />
     </StyledListWrapper>
   );
 };
@@ -80,12 +82,28 @@ const TagBox = ({ tag, isSelected, onClickCategory }: TagBoxProps) => {
 
 interface PlusBoxProps {
   to: string;
+  categoryCount: number;
 }
 
-const PlusBox = ({ to }: PlusBoxProps) => {
+const PlusBox = ({ to, categoryCount }: PlusBoxProps) => {
+  const navigate = useNavigate();
+  const { fireToast } = useToast();
+
+  const onClickPlusBox = () => {
+    if (categoryCount >= MAX_CATEGORY_COUNT) {
+      fireToast({
+        mode: 'ERROR',
+        message: '앗! 카테고리는 최대 20개까지만 만들 수 있어요',
+      });
+    } else {
+      navigate(to);
+    }
+  };
+
   return (
-    <Link to={to}>
+    <>
       <div
+        onClick={onClickPlusBox}
         css={css`
           display: flex;
           align-items: center;
@@ -102,6 +120,6 @@ const PlusBox = ({ to }: PlusBoxProps) => {
       >
         <Icon size="xs" name="plus-dark" />
       </div>
-    </Link>
+    </>
   );
 };

--- a/src/bookmarks/ui/Main/BookmarkAddBS.tsx
+++ b/src/bookmarks/ui/Main/BookmarkAddBS.tsx
@@ -212,7 +212,7 @@ const PublishScoped = ({
           display: flex;
           flex-direction: row;
           column-gap: ${getRem(10)};
-          margin-bottom: ${getRem(25)};
+          margin-bottom: ${getRem(90)};
         `}
       >
         <Button

--- a/src/category/service/hooks/useCategoryMode.tsx
+++ b/src/category/service/hooks/useCategoryMode.tsx
@@ -1,7 +1,9 @@
 import { Mode } from '@/category';
 import TriggerBottomSheet from '@/common-ui/BottomSheet/TriggerBottomSheet';
 import Text from '@/common-ui/Text';
+import useToast from '@/common-ui/Toast/hooks/useToast';
 import IconButton from '@/common/ui/IconButton';
+import { MAX_CATEGORY_COUNT } from '@/store/bookmark';
 import getRem from '@/utils/getRem';
 import styled from '@emotion/styled';
 import { Dispatch, SetStateAction } from 'react';
@@ -9,6 +11,7 @@ import { useNavigate } from 'react-router-dom';
 
 interface CategoryModeProps {
   mode: Mode;
+  categoryLength: number;
   setMode: Dispatch<SetStateAction<Mode>>;
   openDeleteCategoryBS: () => void;
   onClickSaveOrder: () => void;
@@ -16,12 +19,21 @@ interface CategoryModeProps {
 
 const useCategoryMode = ({
   mode,
+  categoryLength,
   setMode,
   openDeleteCategoryBS,
   onClickSaveOrder,
 }: CategoryModeProps) => {
   const router = useNavigate();
+  const { fireToast } = useToast();
   const navigateToCategoryAddPage = () => {
+    if (categoryLength >= MAX_CATEGORY_COUNT) {
+      fireToast({
+        message: '앗! 카테고리는 최대 20개까지만 만들 수 있어요',
+        mode: 'ERROR',
+      });
+      return;
+    }
     router('/category/add', {
       state: {
         fromPath: location.pathname,

--- a/src/pages/CategoryListPage.tsx
+++ b/src/pages/CategoryListPage.tsx
@@ -50,6 +50,7 @@ const CategoryListPage = () => {
 
   const { headerRight } = useCategoryMode({
     mode,
+    categoryLength: clientCategoryList.length,
     setMode,
     openDeleteCategoryBS: open,
     onClickSaveOrder,

--- a/src/store/bookmark.ts
+++ b/src/store/bookmark.ts
@@ -1,6 +1,8 @@
 import { READ_OPTION } from '@/bookmarks/service/hooks/home/useReadList';
 import { create } from 'zustand';
 
+export const MAX_CATEGORY_COUNT = 20 as const;
+
 interface OptionType {
   value: string | null;
   label: string;

--- a/src/store/toast.ts
+++ b/src/store/toast.ts
@@ -18,7 +18,8 @@ export type ToastMessage =
   | '앗! 제목을 입력해주세요'
   | '앗! 중복된 닉네임이에요'
   | '앗! 에러가 발생했어요'
-  | 'URL이 복사되었어요';
+  | 'URL이 복사되었어요'
+  | '앗! 카테고리는 최대 20개까지만 만들 수 있어요';
 
 export type ToastMode = 'SUCCESS' | 'DELETE' | 'ERROR';
 


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #330
- PR의 메인 내용

1. 카테고리가 많을 시 공개 범위선택 가려지던 오류 수정
2. 카테고리 20개 이상 추가 시 toast 추가

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] BookmarkAddBS 스타일 수정
- [x] 카테고리 추가 페이지 이동 전 길이 판단하여 Toast 띄우도록 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
