### PR TITLE
fix: 검색 화면에서 차단 유저 보여주도록 수정

### DIFF
--- a/src/friend/ui/buttons/BlockedButton.tsx
+++ b/src/friend/ui/buttons/BlockedButton.tsx
@@ -1,0 +1,38 @@
+import Button from '@/common-ui/Button';
+import styled from '@emotion/styled';
+import getRem from '@/utils/getRem';
+import { theme } from '@/styles/theme';
+import { type MouseEvent } from 'react';
+import useToast from '@/common-ui/Toast/hooks/useToast';
+import Text from '@/common-ui/Text';
+
+const BlockedButton = () => {
+  const { fireToast } = useToast();
+
+  const onClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    fireToast({
+      message: '차단된 사용자 입니다',
+      mode: 'ERROR',
+    });
+  };
+  return (
+    <StyledButton onClick={onClick} buttonColor={'black'}>
+      <Text.Span color="white" fontSize={0.8}>
+        차단 유저
+      </Text.Span>
+    </StyledButton>
+  );
+};
+
+export default BlockedButton;
+
+const StyledButton = styled(Button)`
+  width: ${getRem(70)};
+  font-size: ${getRem(14)};
+  padding: ${getRem(5, 20)};
+  height: fit-content;
+  color: ${theme.colors.white};
+  font-weight: bold;
+  background-color: ${theme.colors.grey700};
+`;

--- a/src/friend/ui/buttons/FollowButton.tsx
+++ b/src/friend/ui/buttons/FollowButton.tsx
@@ -8,6 +8,7 @@ import { usePOSTFollowUserQuery } from '@/friend/api/friends';
 import useSearchStore from '@/store/search';
 import useToast from '@/common-ui/Toast/hooks/useToast';
 import Text from '@/common-ui/Text';
+import { css } from '@emotion/react';
 
 interface FollowButtonProps {
   memberId: number;
@@ -43,7 +44,13 @@ const FollowButton = ({
   };
   return (
     <StyledButton onClick={onClick} buttonColor={'black'}>
-      <Text.Span color="white" fontSize={0.8}>
+      <Text.Span
+        color="white"
+        fontSize={0.8}
+        css={css`
+          text-shadow: 1px 1px 10px black;
+        `}
+      >
         팔로우
       </Text.Span>
     </StyledButton>

--- a/src/friend/ui/friend/FriendFollowerItem.tsx
+++ b/src/friend/ui/friend/FriendFollowerItem.tsx
@@ -1,6 +1,7 @@
 import FriendItemLayout from '@/friend/ui/friend/layout/FriendItemLayout';
 import FollowButton from '@/friend/ui/buttons/FollowButton';
 import UnFollowButton from '@/friend/ui/buttons/UnFollowButton';
+import BlockedButton from '../buttons/BlockedButton';
 
 type FriendFollowerProps = {
   id: number;
@@ -24,7 +25,9 @@ const FriendFollowerItem = ({
       name={name}
       emoji={profileEmoji}
       button={
-        isFollowing ? (
+        isBlocked ? (
+          <BlockedButton />
+        ) : isFollowing ? (
           <UnFollowButton
             followerId={memberId}
             memberId={id}

--- a/src/store/toast.ts
+++ b/src/store/toast.ts
@@ -26,7 +26,8 @@ export type ToastMessage =
   | '앗! 카테고리 이름이 비어있어요'
   | '삭제 되었습니다'
   | '추가 되었습니다'
-  | '수정 되었습니다';
+  | '수정 되었습니다'
+  | '차단된 사용자 입니다';
 
 export type ToastMode = 'SUCCESS' | 'DELETE' | 'ERROR';
 


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #373
- PR의 메인 내용

1. 검색 화면에서 차단 유저 보여주도록 수정

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] BlockedButton 추가
- [x] toast 메시지 추가
- [x] 팔로우 버튼 text shadow 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
